### PR TITLE
Create contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributions Guidelines
+
+## Basics
+The main language of this project is supposed to be RUST. Therefore contributions should be able to be used in rust.
+
+## Signing your work
+
+In an effort to ensure that the code you contribute is actually compatible with the licenses in this codebase, we require you to sign-off all your contributions.
+
+This can be done by appending `-s` to your `git commit` call, or by manually appending the following text to your commit message:
+
+```text
+<commit message>
+
+Signed-off-by: Author name <Author email>
+```
+
+By signing off your work, you agree to the terms below:
+
+```text
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+These terms will be enforced once you create a pull request, and you will be informed automatically if any of your commits aren't signed-off by you.
+
+As a bonus, you can also [cryptographically sign your commits][gh-signing-commits] and enable [vigilant mode][gh-vigilant-mode] on GitHub.
+
+[gh-signing-commits]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
+[gh-vigilant-mode]: https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits


### PR DESCRIPTION
Just a few guidelines for contributing, mostly for licensing purpose and better handling of legal issues.